### PR TITLE
Make pFUnit optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,13 +118,17 @@ add_test(NAME test_io_nxtbuf         COMMAND test_io_nxtbuf         )
 add_test(NAME test_io_parse_from_fid COMMAND test_io_parse_from_fid )
 add_test(NAME test_io_sprint         COMMAND test_io_sprint         )
 
-#Create test scenarios
-find_package(PFUNIT REQUIRED)
-#enable_testing()
 
-if (PFUNIT_FOUND)
-add_subdirectory(pFUnittests)
+if (ENABLE_PFUNIT)
+	#Create test scenarios
+	find_package(PFUNIT REQUIRED)
+	#enable_testing()
+
+	if (PFUNIT_FOUND)
+	add_subdirectory(pFUnittests)
+	endif()
 endif()
+
 
 # Generate API documentation with Doxygen
 find_package(Doxygen)

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ fi
 cd build
 echo "Executing cmake"
 
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=ON -DENABLE_POSTGRESQL_SUPPORT=ON ../
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=ON -DENABLE_POSTGRESQL_SUPPORT=ON -DENABLE_PFUNIT=ON ../
 echo "Running make install"
 make install
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
For dependencies, pfunit is not necessary, so we should avoid compiling it since it is not an easy dependency