### PR TITLE
Update slam_randomNumber.f90

### DIFF
--- a/src/math/slam_randomNumber.f90
+++ b/src/math/slam_randomNumber.f90
@@ -213,10 +213,12 @@ contains
     else if(iopt == RANDOM_NORMAL .or. iopt == RANDOM_LOG_NORMAL) then
 
       !** check if there is already a number available
-      if(isOtherNumber(iopt) .and. (xmean_prev == xmean) .and. (xsigma_prev == xsigma)) then
+      if(isOtherNumber(iopt)) then 
+        if ((xmean_prev == xmean) .and. (xsigma_prev == xsigma)) then
 
-        getRandomNumber     = otherNumber(iopt)
-        isOtherNumber(iopt) = .false.
+          getRandomNumber     = otherNumber(iopt)
+          isOtherNumber(iopt) = .false.
+        end if
 
       else  !** generate two new numbers
 


### PR DESCRIPTION
The if clause in line 216 doesn't work with the current ifx compiler as it doesn't necessarily check the if statements sequentially and stops after finding the first untrue argument. These if arguments have to be separated as is done within this change.