### PR TITLE
Logger in a single line and fix cmake generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 build/
 doc/latex/
 .DS_store
+*.mod

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@
 BUILD_TYPE=Debug
 Fortran_COMPILER=gfortran
 LIBSUFFIX="so"
+GENERATOR_FLAGS=""
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   LIBSUFFIX="so"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -14,7 +15,7 @@ elif [[ "$OSTYPE" == "MINGW"* ]]; then
   LIBSUFFIX="dll"
 elif [[ "$OSTYPE" == "msys"* ]]; then
   LIBSUFFIX="dll"
-  GENERATOR="MSYS Makefiles"
+  GENERATOR_FLAGS="-G MSYS Makefiles"
 fi
 git submodule update --init --recursive 
 ################################################################################
@@ -33,7 +34,7 @@ cd build || exit || exit
 echo "Updating cmake"
 export PFUNIT_DIR=..//pFUnit/build/installed
 export FC=$Fortran_COMPILER
-cmake -DSKIP_MPI=yes -G "$GENERATOR" ../
+cmake -DSKIP_MPI=yes "$GENERATOR_FLAGS" ../
 echo "Building pFUnit"
 cmake --build .
 cmake --install .
@@ -54,7 +55,7 @@ fi
 cd build || exit || exit
 echo "Executing cmake"
 
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=ON -DENABLE_POSTGRESQL_SUPPORT=ON -DENABLE_PFUNIT=ON -G "$GENERATOR" ../
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=ON -DENABLE_POSTGRESQL_SUPPORT=ON -DENABLE_PFUNIT=ON "$GENERATOR_FLAGS" ../
 echo "Building libslam"
 cmake --build .
 cmake --install .

--- a/src/inout/slam_error_handling.f90
+++ b/src/inout/slam_error_handling.f90
@@ -1396,13 +1396,13 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = DEBUG_MSG
       if (cli_verbosity >= DEBUG_MSGS) then    ! CLI output
 
-        write(*,'(a)') trim(C_DEBUG_MSG(errorLanguage))//trim(ctemp)//': '//trim(cmess)
+        write(*,'(a)') trim(C_DEBUG_MSG(errorLanguage))//':'//trim(ctemp)//':'//trim(cmess)
 
       end if
 
       if (log_verbosity >= DEBUG_MSGS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)') trim(C_DEBUG_MSG(errorLanguage))//trim(ctemp)//': '//trim(cmess)
+        write(ichlog,'(a)') trim(C_DEBUG_MSG(errorLanguage))//':'//trim(ctemp)//trim(cmess)//':'
 
       end if
 
@@ -1411,7 +1411,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = REMARK
       if (cli_verbosity >= REMARKS) then    ! CLI output
 
-        write(*,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//':'//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1429,7 +1429,7 @@ subroutine setError(code, err_type, par, errorMessage)
 
       if (log_verbosity >= REMARKS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
+        write(ichlog,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//':'//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1450,7 +1450,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = WARNING
       if (cli_verbosity >= WARNINGS) then    ! CLI output
 
-        write(*,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//':'//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1468,7 +1468,7 @@ subroutine setError(code, err_type, par, errorMessage)
 
       if (log_verbosity >= WARNINGS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
+        write(ichlog,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//':'//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1489,7 +1489,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = FATAL
       if (cli_verbosity >= ERRORS) then    ! CLI output
 
-        write(*,'(a)', advance = "no") trim(C_FATAL(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_FATAL(errorLanguage))//':'//trim(ctemp)//':'
         write(*,'(a)') '  '//trim(cmess)
         if(errorAction == ERR_ABORT) write(*,'(a)') '  '//C_TERMINATED(errorLanguage)
 
@@ -1497,7 +1497,7 @@ subroutine setError(code, err_type, par, errorMessage)
 
       if (log_verbosity >= ERRORS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)') trim(C_FATAL(errorLanguage))//trim(ctemp)//':'
+        write(ichlog,'(a)', advance = "no") trim(C_FATAL(errorLanguage))//':'//trim(ctemp)//':'
         write(ichlog,'(a)') '  '//trim(cmess)
         if(errorAction == ERR_ABORT) write(ichlog,'(a)') '  '//C_TERMINATED(errorLanguage)
 

--- a/src/inout/slam_error_handling.f90
+++ b/src/inout/slam_error_handling.f90
@@ -1411,7 +1411,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = REMARK
       if (cli_verbosity >= REMARKS) then    ! CLI output
 
-        write(*,'(a)') trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1429,7 +1429,7 @@ subroutine setError(code, err_type, par, errorMessage)
 
       if (log_verbosity >= REMARKS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)') trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
+        write(ichlog,'(a)', advance = "no") trim(C_REMARK(errorLanguage))//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1450,7 +1450,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = WARNING
       if (cli_verbosity >= WARNINGS) then    ! CLI output
 
-        write(*,'(a)') trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1468,7 +1468,7 @@ subroutine setError(code, err_type, par, errorMessage)
 
       if (log_verbosity >= WARNINGS .and. flag_ichlog) then    ! logfile output
 
-        write(ichlog,'(a)') trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
+        write(ichlog,'(a)', advance = "no") trim(C_WARNING(errorLanguage))//trim(ctemp)//':'
         ! Prepare the message based on the optional parameter or the predefined message
         if(present(par)) then
             do i = 1, SIZE_ERROR_PARAMETER
@@ -1489,7 +1489,7 @@ subroutine setError(code, err_type, par, errorMessage)
       latestErrorType = FATAL
       if (cli_verbosity >= ERRORS) then    ! CLI output
 
-        write(*,'(a)') trim(C_FATAL(errorLanguage))//trim(ctemp)//':'
+        write(*,'(a)', advance = "no") trim(C_FATAL(errorLanguage))//trim(ctemp)//':'
         write(*,'(a)') '  '//trim(cmess)
         if(errorAction == ERR_ABORT) write(*,'(a)') '  '//C_TERMINATED(errorLanguage)
 


### PR DESCRIPTION
Apart from removing the cmake generator stuff for targets different than MSYS, it changes the way the logger messages are displayed

New version:

![image](https://github.com/user-attachments/assets/f9786e8d-a3cd-47fe-b132-8681cd4a7e1d)

Old version:

![image](https://github.com/user-attachments/assets/5580f802-34ee-4614-8ba6-8b30aad71b2a)

